### PR TITLE
added possibility to configure external client's location for docker container

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,4 @@ DB_PASSWORD=password
 
 # game db
 GAME_DB_URL=https://drive.google.com/uc?export=download&id=1Y8bAJSFb9BlhR0WwtuBs9bnLQ8pq3ZVj
+CLIENT_DATA="~/Games/Archeage/AAClient 1.2"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,8 @@ services:
                 - GAME_DB_URL=${GAME_DB_URL}
         image: aaemu-game:${PROJECT_VERSION_PREFIX}-${PROJECT_VERSION_SUFFIX}
         restart: unless-stopped
+        volumes:
+          - ${CLIENT_DATA}:/app/ClientData:ro
         environment:
             DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
         ports:


### PR DESCRIPTION
Location to the client data sits in .env file in CLIENT_DATA property
It will be mounted to the AAEmu.Game docker container with read-only permissions